### PR TITLE
Enable dotSize in the MDS plot to be adjustable

### DIFF
--- a/Engines/figureMDSArrangement.m
+++ b/Engines/figureMDSArrangement.m
@@ -163,8 +163,8 @@ if isfield(localOptions,'figI_textLabels')&&~isempty(localOptions.figI_textLabel
         % categories undefined: plot all text labels in black
 		veryLocalOptions.textLabels = localOptions.textLabels;
 		veryLocalOptions.dotColours = localOptions.dotColours;
-		if isfield(localOptions, 'dotSize')
-			veryLocalOptions.dotSize = localOptions.dotSize;
+		if isfield(userOptions, 'dotSize')
+			veryLocalOptions.dotSize = userOptions.dotSize;
 		end%if
         plotDotsWithTextLabels(pats_mds_2D,veryLocalOptions);
 		


### PR DESCRIPTION
In the original version, dotSize in the MDS plot could not be adjusted by users.
Reason identified:
The dotSize parameter is stored in userOption instead of localOptions, but the old script mistakenly tried to retrieve the dotSize information from the localOption. I edited the code so that dotSize is now rerived from the correct variable.