### PR TITLE
Fix bugs regarding saveas() at the end

### DIFF
--- a/+rsa/+fig/figureMDSArrangement.m
+++ b/+rsa/+fig/figureMDSArrangement.m
@@ -140,7 +140,10 @@ catch
         catch
             description{1}=[RDMname ', MDS failed...'];
         end
-    end   
+    end
+    % If MDS failed at the initial trial, print out comment about the MDS
+    % (e.g., changed criterion, added 0.2 to distance)
+    fprintf(['Fail at the initial MDS trial: ',char(description),'\n']);
 end    
 
 

--- a/+rsa/+fig/figureMDSArrangement.m
+++ b/+rsa/+fig/figureMDSArrangement.m
@@ -140,10 +140,7 @@ catch
         catch
             description{1}=[RDMname ', MDS failed...'];
         end
-    end
-    % If MDS failed at the initial trial, print out comment about the MDS
-    % (e.g., changed criterion, added 0.2 to distance)
-    fprintf(['Fail at the initial MDS trial: ',char(description),'\n']);
+    end   
 end    
 
 

--- a/+rsa/compareRefRDM2candRDMs.m
+++ b/+rsa/compareRefRDM2candRDMs.m
@@ -112,7 +112,7 @@ function stats_p_r=compareRefRDM2candRDMs(refRDM, candRDMs, userOptions)
 %       correlation. (Note that multiple independent measurements of the
 %       reference or candidate RDMs could also come from repeated
 %       measurements within one subject. We refer to the instances as
-%       ìsubjectsî, because subject random-effects inference is the most
+%       ‚Äúsubjects‚Äù, because subject random-effects inference is the most
 %       common case.)
 %
 %       'randomisation': Test the relatedness of the reference RDM to each
@@ -323,6 +323,10 @@ function stats_p_r=compareRefRDM2candRDMs(refRDM, candRDMs, userOptions)
 %       If true(default: false), the figures are saved in post-script
 %       format in userOptions.resultsPath.
 %
+% userOptions.saveFigureEPS
+%       If true(default: false), the figures are saved in EPS format in 
+%       userOptions.resultsPath.
+%
 % userOptions.saveFigureFig
 %       If true (default: false), the figures are saved in Matlab .fig
 %       format in userOptions.resultsPath.
@@ -354,14 +358,6 @@ function stats_p_r=compareRefRDM2candRDMs(refRDM, candRDMs, userOptions)
 %                                    values)
 %       stats_p_r.ceiling:           ceiling lower and upper bounds
 
-import rsa.*
-import rsa.fig.*
-import rsa.fmri.*
-import rsa.rdm.*
-import rsa.sim.*
-import rsa.spm.*
-import rsa.stat.*
-import rsa.util.*
 
 %% set default options
 userOptions = setIfUnset(userOptions, 'RDMcorrelationType', 'Spearman');
@@ -379,6 +375,10 @@ userOptions = setIfUnset(userOptions, 'figureIndex',[1 2]);
 userOptions = setIfUnset(userOptions, 'resultsPath',pwd);
 userOptions = setIfUnset(userOptions, 'saveFigurePDF', true);
 userOptions = setIfUnset(userOptions, 'saveFigurePS', false);
+userOptions = setIfUnset(userOptions, 'saveFigureFig', false);
+userOptions = setIfUnset(userOptions, 'saveFigureEPS', false);
+
+
 userOptions = setIfUnset(userOptions, 'figure1filename', 'compareRefRDM2candRDMs_barGraph');
 userOptions = setIfUnset(userOptions, 'figure2filename', 'compareRefRDM2candRDMs_RDMcomparisonPvalues');
 
@@ -1041,19 +1041,19 @@ title({'\bfthresholded to control the FWE (Bonferroni)',['\rmblack: n.s., dark r
 handleCurrentFigure([userOptions.resultsPath,filesep,userOptions.figure2filename],userOptions);
 
 
-%% save it
-cd(fullfile(userOptions.rootPath));
-if userOptions.saveFiguresPS
-    saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.eps'],'eps');
-end
-if userOptions.saveFiguresFig
-    saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.fig'],'fig');
-end
-if userOptions.saveFiguresPDF
-    exportCurrentFigAsPDF([userOptions.analysisName,'_comparingRefRDM2CandRDMs'],userOptions);
-end
-if userOptions.saveFiguresPS
-    exportCurrentFigAsPostscript([userOptions.analysisName,'.ps'],userOptions);
-end
-
-end%function
+%% save it (no longer needed)
+% Saving plot to file has already been handled by handleCurrentFigure()
+% above.
+% cd(fullfile(userOptions.rootPath));
+% if userOptions.saveFigureEPS
+%     saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.eps'],'eps');
+% end
+% if userOptions.saveFigureFig
+%     saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.fig'],'fig');
+% end
+% if userOptions.saveFigurePDF
+%     exportCurrentFigAsPDF([userOptions.analysisName,'_comparingRefRDM2CandRDMs'],userOptions);
+% end
+% if userOptions.saveFigurePS
+%     exportCurrentFigAsPostscript([userOptions.analysisName,'.ps'],userOptions);
+% end


### PR DESCRIPTION
(1)Comment out the saveas() block at the end (line 1044).
"gcf" has already been closed by handleCurrentFigure() (line 942 and 1041), and the plots have already been saved as files.
Thus, any attempt to call saveas(gcf,...) is needless. ( With gcf being closed, this will only save a blank file).

In case if one would like to keep the saveas() block uncommented, there are several bugs to be fixed.
(2)Initiate userOptions.saveFigureFig in the "set default options" block.
Error Message: 
Reference to non-existent field 'saveFigureFig'.
line 1051 in compareRefRDM2candRDMs.m.
Reason:
The field 'userOptions.saveFigureFig' is not initiated at the "set default options" block.

(3)Typo: "userOptions.saveFigureEPS" is mistakenly typed as "userOptions.savesFigurePS". (line 1048)
Old:
if userOptions.saveFiguresPS
    saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.eps'],'eps');
end
Fixed:
if userOptions.saveFigureEPS
     saveas(gcf,[userOptions.analysisName,'_comparingRefRDM2CandRDMs','.eps'],'eps');
end